### PR TITLE
Fix registration bug

### DIFF
--- a/frontend/src/services/registration.js
+++ b/frontend/src/services/registration.js
@@ -37,6 +37,15 @@ export class RegistrationService {
       };
     }
 
+    if (registerResult.response.data.error === 1) {
+      return {
+        error: true,
+        message: registerResult.response.data.errorMsg,
+        uuid: "",
+        token: ""
+      };
+    }
+
     const authTokenResult = await this.authNodeConnector.sendGenerateAuthTokenRequest(
       { username, password }
     );
@@ -44,6 +53,15 @@ export class RegistrationService {
       return {
         error: authTokenResult.error,
         message: authTokenResult.message,
+        uuid: "",
+        token: ""
+      };
+    }
+
+    if (authTokenResult.response.data.error === 1) {
+      return {
+        error: true,
+        message: "Something went wrong",
         uuid: "",
         token: ""
       };


### PR DESCRIPTION
Registering with a user id that already exists in the system was crashing the frontend. This is because, while we were checking to make sure that our post requests returned successfully, we didn't check to see if there were any error messages in the response data.

We are now unpacking the data and checking to see if there are any errors within, similar to what we're already doing in the `service/login.js`.